### PR TITLE
feat: add individual msg for each record processing in bulk

### DIFF
--- a/packages/domain-lib/src/types.ts
+++ b/packages/domain-lib/src/types.ts
@@ -88,3 +88,9 @@ export interface IPublicKeyInfo {
     participantId: string;
     publicKey: string;
 }
+
+export declare type BulkApprovalRequestResults = {
+  reqId: string;
+  status: "success" | "error";
+  message: string;
+}

--- a/packages/implementations-lib/src/certs/mongo_certs_repo.ts
+++ b/packages/implementations-lib/src/certs/mongo_certs_repo.ts
@@ -572,7 +572,7 @@ export class MongoCertsRepo implements ICertRepo {
 
         await this.approvalsCollection.updateOne(
             { participantId: participantId },
-            { $pull: { participantCertificateUploadRequests: { _id: new ObjectId(certificateId) } } }
+            { $pull: { participantCertificateUploadRequests: { _id: new ObjectId(certificateId) } } } as any
         ).catch((e: unknown) => {
             this._logger.error(
                 `Unable to delete certificate request: ${(e as Error).message}`
@@ -691,7 +691,7 @@ export class MongoCertsRepo implements ICertRepo {
         // Remove from approvalsCollection
         await this.approvalsCollection.updateOne(
             { participantId: participantId },
-            { $pull: { participantCertificateUploadRequests: { _id: certificate._id } } }
+            { $pull: { participantCertificateUploadRequests: { _id: certificate._id } } } as any
         );
     }
 


### PR DESCRIPTION
instead of bulk process and show single success/error msg.
show individual error/success for each record in bulk route.
if a participant has multiple Certificates Requests and try to bulk approve, Latest New one will used and overwrite everything else of that participant

https://github.com/mojaloop/project/issues/3717